### PR TITLE
Remove ignoring of HEX decoding errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bloxapp/vault-plugin-secrets-eth2.0
 go 1.14
 
 require (
-	github.com/bloxapp/KeyVault v0.1.8
+	github.com/bloxapp/KeyVault v0.0.0-20200708115512-06f383cbcd3b
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/vault/sdk v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,11 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bloxapp/KeyVault v0.0.0-20200702084557-9df8b01ada4c h1:jeDtA5qxe00ItxBNgKY5wmztPxzSUzNNw/aaCF3q9AY=
 github.com/bloxapp/KeyVault v0.0.0-20200702084557-9df8b01ada4c/go.mod h1:MO+HB1iiUhgRVftZCi5ww4gqR4/WXSdQDIRj8dHCKNw=
+github.com/bloxapp/KeyVault v0.0.0-20200708112608-51abacecddba h1:m/q8Xow3XVVEfGWMmmsblr96QPeVUAbG9XouGKGYKj0=
+github.com/bloxapp/KeyVault v0.0.0-20200708112608-51abacecddba/go.mod h1:MO+HB1iiUhgRVftZCi5ww4gqR4/WXSdQDIRj8dHCKNw=
+github.com/bloxapp/KeyVault v0.0.0-20200708115512-06f383cbcd3b h1:uFTLEkaKHMA27EPRTALNhSIkhCe5Tnl64b/TH4m13dg=
+github.com/bloxapp/KeyVault v0.0.0-20200708115512-06f383cbcd3b/go.mod h1:MO+HB1iiUhgRVftZCi5ww4gqR4/WXSdQDIRj8dHCKNw=
+github.com/bloxapp/KeyVault v0.1.8 h1:JJ8TSoy8zqHO5DZQFWlONWr6okWEcbt+AXGSPTYAPeo=
 github.com/bloxapp/KeyVault v0.1.8/go.mod h1:MO+HB1iiUhgRVftZCi5ww4gqR4/WXSdQDIRj8dHCKNw=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=


### PR DESCRIPTION
The reason to do this is to avoid the wrong signing behavior in a case when the incoming data would be non HEX encoded. For instance, there could be a non HEX encoded beacon block root and the result of HEX decoding would be always an empty bytes array. This is the wrong behavior.